### PR TITLE
Got rid of smart quotes to prevent test failures on POD checking

### DIFF
--- a/README
+++ b/README
@@ -59,5 +59,5 @@ COPYRIGHT & LICENSE
     of the licenses in the directory LICENSES.
 
     This module is distributed in the hope that it will be useful, but it is
-    provided “as is” and without any express or implied warranties.
+    provided "as is" and without any express or implied warranties.
 

--- a/lib/Catalyst/View/Thumbnail.pm
+++ b/lib/Catalyst/View/Thumbnail.pm
@@ -258,7 +258,7 @@ as Perl 5.10.0. For more details, see the full text of the
 licenses in the directory LICENSES.
 
 This module is distributed in the hope that it will be
-useful, but it is provided “as is” and without any express
+useful, but it is provided "as is" and without any express
 or implied warranties. 
 
 =cut


### PR DESCRIPTION
Most systems now seem to be rendering those quotes badly.  I just changed them to regular double quotes.
